### PR TITLE
Fixed issues

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -54,7 +54,7 @@ async function addCSS() {
 
     // Improve "Sponsored" content label
     if (setting.betterSponsor) {
-        css[2] = await browser.contentScripts.register({
+        css[3] = await browser.contentScripts.register({
             matches: [facebook, facebookOnion],
             css: [{
                 file: 'styles/better_sponsor.css'
@@ -108,5 +108,5 @@ browser.runtime.onInstalled.addListener(handleInstalled);
 browser.pageAction.onClicked.addListener(openOptions);
 const facebook = '*://*.facebook.com/*';
 const facebookOnion = '*://*.facebookcorewwwi.onion/*';
-const css = [null, null, null];
+const css = [null, null, null, null];
 addCSS();

--- a/firefox/styles/no_like_buttons.css
+++ b/firefox/styles/no_like_buttons.css
@@ -4,6 +4,7 @@
 
 li._6coj:first-of-type,
 li._6coj:nth-of-type(2) ._6cok,
-._18vi:first-of-type {
+._18vi:first-of-type,
+.rq0escxv.l9j0dhe7.du4w35lb.j83agx80.pfnyh3mw.i1fnvgqd.gs1a9yip.owycx6da.btwxx1t3.ph5uu5jm.b3onmgus.e5nlhep0.ecm0bbzt.nkwizq5d.roh60bw9.mysgfdmx.hddg9phg > div:first-child {
   display: none !important;
 }


### PR DESCRIPTION
Fixed a typo that causes the like button setting to be permanent if the sponsored setting is enabled. Closes #19.

Updated the CSS selector for fixing the like button on posts. Closes #18.